### PR TITLE
Update to Bevy 0.14. Switch from bevy_xpbd_2d to avian2d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,25 +12,25 @@ keywords = ["bevy", "rapier", "png", "collider", "2d"]
 readme = "README.md"
 
 [features]
-default = ["xpbd_2d", "rapier2d"]
-xpbd_2d = ["dep:bevy_xpbd_2d"]
+default = ["avian2d", "rapier2d"]
+avian2d = ["dep:avian2d"]
 rapier2d = ["dep:bevy_rapier2d"]
 
 [dependencies]
-bevy = "0.13.0"
-bevy_rapier2d = { version = "0.25.0", optional = true }
-bevy_xpbd_2d = { version = "0.4.2", optional = true }
-edges = { version = "0.3.2", features = ["bevy"] }
+bevy = "0.14"
+bevy_rapier2d = { version = "0.27.0", optional = true }
+avian2d = { version = "0.1.0", optional = true }
+edges = { version = "0.3.4", features = ["bevy"] }
 thiserror = "1.0.57"
 
 [dev-dependencies]
-bevy_prototype_lyon = "0.11.0"
+bevy_prototype_lyon = "0.12.0"
 indoc = "2.0.4"
 
 [[example]]
-name = "xpbd_2d_colliders"
-path = "examples/xpbd_2d_colliders.rs"
-required-features = ["xpbd_2d"]
+name = "avian2d_colliders"
+path = "examples/avian2d_colliders.rs"
+required-features = ["avian2d"]
 
 [[example]]
 name = "rapier2d_colliders"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a library for generating 2d colliders, for bevy apps, from images with transpare
 
 ## specifying your dependency
 
-by default, both bevy_rapier2d and bevy_xpbd_2d are enabled. this is to help with the out of box experience, specifically, being able to run both examples and tinker.
+by default, both bevy_rapier2d and avian2d (formerly bevy_xpbd_2d) are enabled. this is to help with the out of box experience, specifically, being able to run both examples and tinker.
 
 but you'll probably only want to just use one of the physics engines supported so when you use it in your own crate fill in in the `bevy_collider_gen` dependencies with something like this for `bevy_rapier2d`
 
@@ -20,13 +20,13 @@ features = ["rapier2d"]
 default-features = false
 ```
 
-or this for `bevy_xpbd_2d`
+or this for `avian2d`
 
 ```toml
 [dependencies.bevy_collider_gen]
 # replace "*" with the most recent version of bevy_collider_gen
 version = "*"
-features = ["xpbd_2d"]
+features = ["avian2d"]
 default-features = false
 ```
 
@@ -44,12 +44,12 @@ to see this in action you can run the example, with no args it generates a scene
 cargo run --example rapier2d_colliders
 ```
 
-### bevy_xpbd_2d
+### avian2d
 
-#### note that you must have the xpbd_2d feature enabled
+#### note that you must have the avian2d feature enabled
 
 ```sh
-cargo run --example xpbd_2d_colliders
+cargo run --example avian2d_colliders
 ```
 
 you can also specify a path to an image yourself the example will attempt to generate one or more convex_polyline colliders for the objects it finds

--- a/examples/avian2d_colliders.rs
+++ b/examples/avian2d_colliders.rs
@@ -1,10 +1,13 @@
+use avian2d::math::Vector;
+use avian2d::prelude::*;
 use bevy::asset::LoadState;
+use bevy::color::palettes::css;
 use bevy::pbr::wireframe::WireframePlugin;
 use bevy::prelude::*;
 use bevy::render::settings::{RenderCreation, WgpuFeatures, WgpuSettings};
 use bevy::render::RenderPlugin;
 use bevy_collider_gen::{
-    xpbd_2d::{
+    avian2d::{
         multi_convex_polyline_collider_translated, single_convex_polyline_collider_translated,
         single_heightfield_collider_translated,
     },
@@ -12,11 +15,6 @@ use bevy_collider_gen::{
 };
 use bevy_prototype_lyon::prelude::{Fill, GeometryBuilder, ShapePlugin};
 use bevy_prototype_lyon::shapes;
-use bevy_xpbd_2d::components::RigidBody;
-use bevy_xpbd_2d::math::Vector;
-use bevy_xpbd_2d::plugins::debug::DebugRender;
-use bevy_xpbd_2d::plugins::{PhysicsDebugPlugin, PhysicsPlugins};
-use bevy_xpbd_2d::resources::Gravity;
 use indoc::indoc;
 use std::collections::HashMap;
 
@@ -52,7 +50,7 @@ pub fn custom_png_spawn(
                 transform: Transform::from_xyz(0.0, 0.0, 0.0),
                 ..default()
             },
-            DebugRender::default().with_collider_color(Color::VIOLET),
+            DebugRender::default().with_collider_color(css::VIOLET.into()),
         ));
     }
 }
@@ -86,7 +84,7 @@ pub fn car_spawn(
         },
         Car { initial_xyz },
         RigidBody::Dynamic,
-        DebugRender::default().with_collider_color(Color::VIOLET),
+        DebugRender::default().with_collider_color(css::VIOLET.into()),
     ));
 }
 
@@ -110,7 +108,7 @@ pub fn terrain_spawn(
             texture: sprite_handle.unwrap().clone(),
             ..default()
         },
-        DebugRender::default().with_collider_color(Color::VIOLET),
+        DebugRender::default().with_collider_color(css::VIOLET.into()),
     ));
 }
 
@@ -138,7 +136,7 @@ pub fn boulders_spawn(
             closed: true,
         };
         let geometry = GeometryBuilder::build_as(&shape);
-        let fill = Fill::color(Color::hex("545454").unwrap());
+        let fill = Fill::color(Srgba::hex("#545454").unwrap());
         let transform = Transform::from_xyz(0., 40., 0.);
 
         commands.spawn((
@@ -147,7 +145,7 @@ pub fn boulders_spawn(
             fill,
             transform,
             RigidBody::Dynamic,
-            DebugRender::default().with_collider_color(Color::VIOLET),
+            DebugRender::default().with_collider_color(css::VIOLET.into()),
         ));
     }
 }
@@ -171,7 +169,6 @@ pub struct GameAsset {
 
 fn main() {
     App::new()
-        .init_state::<AppState>()
         .add_plugins(
             DefaultPlugins
                 .set(WindowPlugin {
@@ -193,8 +190,9 @@ fn main() {
                     ..default()
                 }),
         )
+        .init_state::<AppState>()
         .insert_resource(GameAsset::default())
-        .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
+        .insert_resource(ClearColor(Color::srgb(0.0, 0.0, 0.0)))
         .insert_resource(Gravity(Vector::NEG_Y * 1000.0))
         .add_plugins(ShapePlugin)
         .add_plugins(WireframePlugin)
@@ -234,7 +232,9 @@ pub fn check_assets(
         }
     }
 
-    if Some(LoadState::Loaded) != asset_server.get_load_state(game_assets.font_handle.clone()) {
+    if Some(LoadState::Loaded)
+        != asset_server.get_load_state(&game_assets.font_handle.clone().untyped())
+    {
         return;
     }
 
@@ -342,7 +342,7 @@ pub fn controls_text_spawn(mut commands: Commands, game_assets: Res<GameAsset>) 
                 style: TextStyle {
                     font: game_assets.font_handle.clone(),
                     font_size: 20.0,
-                    color: Color::rgb(0.9, 0.9, 0.9),
+                    color: Color::srgb(0.9, 0.9, 0.9),
                 },
             }],
             justify: JustifyText::Left,

--- a/examples/rapier2d_colliders.rs
+++ b/examples/rapier2d_colliders.rs
@@ -149,7 +149,7 @@ pub fn boulders_spawn(
             closed: true,
         };
         let geometry = GeometryBuilder::build_as(&shape);
-        let fill = Fill::color(Color::hex("545454").unwrap());
+        let fill = Fill::color(Srgba::hex("#545454").unwrap());
         let transform = Transform::from_xyz(0., 40., 0.);
 
         commands.spawn((
@@ -181,7 +181,6 @@ pub struct GameAsset {
 
 fn main() {
     App::new()
-        .init_state::<AppState>()
         .add_plugins(
             DefaultPlugins
                 .set(WindowPlugin {
@@ -203,8 +202,9 @@ fn main() {
                     ..default()
                 }),
         )
+        .init_state::<AppState>()
         .insert_resource(GameAsset::default())
-        .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
+        .insert_resource(ClearColor(Color::srgb(0.0, 0.0, 0.0)))
         .add_plugins(ShapePlugin)
         .add_plugins(WireframePlugin)
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(1.0))
@@ -250,7 +250,9 @@ pub fn check_assets(
         }
     }
 
-    if Some(LoadState::Loaded) != asset_server.get_load_state(game_assets.font_handle.clone()) {
+    if Some(LoadState::Loaded)
+        != asset_server.get_load_state(&game_assets.font_handle.clone().untyped())
+    {
         return;
     }
 
@@ -358,7 +360,7 @@ pub fn controls_text_spawn(mut commands: Commands, game_assets: Res<GameAsset>) 
                 style: TextStyle {
                     font: game_assets.font_handle.clone(),
                     font_size: 20.0,
-                    color: Color::rgb(0.9, 0.9, 0.9),
+                    color: Color::srgb(0.9, 0.9, 0.9),
                 },
             }],
             justify: JustifyText::Left,

--- a/src/collider/avian2d.rs
+++ b/src/collider/avian2d.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::{Image, Vec2};
-use bevy_xpbd_2d::{
+use avian2d::{
     math::Vector2,
     parry::{
         math::{Point, Real, Vector},
@@ -8,6 +7,7 @@ use bevy_xpbd_2d::{
     },
     prelude::Collider,
 };
+use bevy::prelude::{Image, Vec2};
 use edges::Edges;
 
 /// Generate a single polyline collider from the image,

--- a/src/collider/mod.rs
+++ b/src/collider/mod.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "xpbd_2d")]
-pub mod xpbd_2d;
+#[cfg(feature = "avian2d")]
+pub mod avian2d;
 
 #[cfg(feature = "rapier2d")]
 pub mod rapier2d;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod collider;
 #[cfg(feature = "rapier2d")]
 pub use collider::rapier2d;
 
-#[cfg(feature = "xpbd_2d")]
-pub use collider::xpbd_2d;
+#[cfg(feature = "avian2d")]
+pub use collider::avian2d;
 
 pub use ::edges::Edges;


### PR DESCRIPTION
Both examples start, and the colliders are nicely generated. The scale in `rapier2d_colliders` feels off. I'm not sure if that's a new issue or if it was already present in the previous version.